### PR TITLE
Allow passing arrays of assets from external query

### DIFF
--- a/tests/ZipperTagsTest.php
+++ b/tests/ZipperTagsTest.php
@@ -69,4 +69,22 @@ class ZipperTagsTest extends TestCase
             $this->assertStringContainsString($file, $url);
         });
     }
+
+    /** @test */
+    public function canHandleMultipleImages()
+    {
+        $files = $this->assetContainer->files();
+
+        $this->tag
+            ->setContext(['images' => $files])
+            ->setParameters(['filename' => 'zip']);
+
+        $this->tag->method = 'images';
+
+        $url = $this->tag->wildcard();
+
+        collect($files)->each(function ($file) use ($url) {
+            $this->assertStringContainsString($file, $url);
+        });
+    }
 }


### PR DESCRIPTION
Came across a situation where I needed to have a global set of items to download as multiple pages needed to share the same data, it didn't make sense to add the same assets across all those pages individual .md files.

So these changes add the ability to pass an array of assets using a query such as:
$downloads = \Statamic\Facades\Asset::whereFolder('downloads', 'assets')->toArray();

**blade example as we use blade**
{{ tag('zip:images', ['filename' => 'zip'], ['images' => $downloads]) }}
